### PR TITLE
Use OpenAI API instead of scraping ChatGPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,33 @@
 # whatsapp-gpt
-* You'll need to run WhatsApp from a phone number using the golang library I'm using.
-* You'll run a dedicated browser in another window that's controlling ChatGPT.
-* Two terminals: `go run main.go`, and `python server.py`. I am extremely doubtful they will work for you on the first run.
-* You can also try `multichat.py` if you want to watch two ChatGPTs talk to each other.
-* This marks the end of the readme file; it is a bit sparse; thankfully the code is too! Just tuck in if you can... and I will try to add more here later.
+
+This repo links WhatsApp messages to OpenAI's ChatGPT through a small Flask
+server and a Go client using [whatsmeow](https://github.com/tulir/whatsmeow).
+
+## Usage
+
+1. Install Python dependencies:
+
+   ```bash
+   pip install flask openai
+   ```
+
+2. Export your OpenAI API key:
+
+   ```bash
+   export OPENAI_API_KEY=your_key_here
+   ```
+
+3. Run the Flask server and WhatsApp client in separate terminals:
+
+   ```bash
+   python server.py
+   go run main.go
+   ```
+
+Incoming WhatsApp messages are forwarded to the local server, which responds
+with OpenAI's ChatCompletion API.
+
+* `multichat.py` can be used to watch two ChatGPTs talk to each other.
+
+This marks the end of the readme file; it is a bit sparse; thankfully the code
+is too! Just tuck in if you can... and I will try to add more here later.


### PR DESCRIPTION
## Summary
- Replace Playwright-based ChatGPT interaction with a simple Flask server using OpenAI's ChatCompletion API
- Update README with setup instructions and API key usage

## Testing
- `python -m py_compile server.py`
- `go build main.go` *(fails: command hung while fetching modules, aborted with Ctrl-C)*

------
https://chatgpt.com/codex/tasks/task_e_68aeaaca7dc4832cac678f07ccc1dd86